### PR TITLE
Remove run-name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,6 @@ on:
       docker_password:
         required: true
 
-run-name: Deploy to ${{ github.event.inputs.env }} release ${{ github.event.inputs.ver }}
-
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run-name is scoped to the workflow level not the job level, so currently it's not possible to rewrite it from here