### PR TITLE
SCRP-1195: Adds java-17-validate-pr reusable workflow

### DIFF
--- a/.github/workflows/java-17-validate-pr.yml
+++ b/.github/workflows/java-17-validate-pr.yml
@@ -29,7 +29,14 @@ jobs:
           checkAllCommitMessages: ${{ inputs.check_all_commit_msg }}
           accessToken: ${{ github.token }} # github access token is only required if checkAllCommitMessages is true
 
+      - name: Check pre-commit config
+        id: pre_commit_config
+        uses: andstor/file-existence-action@v2
+        with:
+          files: ".pre-commit-config.yaml"
+
       - name: Check commit messages
+        if: steps.pre_commit_config.outputs.files_exists == 'true'
         uses: cloudposse/github-action-pre-commit@v2.1.2  # run pre-commit
 
   validate-k8s-configuration:

--- a/.github/workflows/java-17-validate-pr.yml
+++ b/.github/workflows/java-17-validate-pr.yml
@@ -1,0 +1,93 @@
+name: Validate PR
+
+on:
+  workflow_call:
+    inputs:
+      check_all_commit_msg:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate-commit-msg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check for Resolves / Fixes
+        if: github.event_name == 'pull_request' # only work on pull request
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^[A-Z][A-Z0-9]+-[0-9]+: .*$'
+          error: |
+            Your commit message and your PR title must follow the format of 'JIRA-123: '
+            Did you forget to add your jira?
+            Did you follow the correct format?
+
+            Please follow this format so Jira can auto detect what is in each release.
+            The regex is '^[A-Z][A-Z0-9]+-[0-9]+: .*$'
+          checkAllCommitMessages: ${{ inputs.check_all_commit_msg }}
+          accessToken: ${{ github.token }} # github access token is only required if checkAllCommitMessages is true
+
+      - name: Check commit messages
+        uses: cloudposse/github-action-pre-commit@v2.1.2  # run pre-commit
+
+  validate-k8s-configuration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check docker login
+        run: |
+          docker login syd.ocir.io -u ${{secrets.ORACLE_CONTAINER_REGISTRY_DOCKER_USERNAME}} -p "${{secrets.ORACLE_CONTAINER_REGISTRY_DOCKER_PASSWORD}}"
+
+      - name: Check sit k8s helm charts
+        run: |
+          docker run --rm \
+            -v "$(pwd):/apps" \
+            -w /apps \
+            syd.ocir.io/coexservices01/alpine/helm:3.9.0 \
+            template -f /apps/k8s/values/values.sit.yaml --set "version=${{github.run_number}}" /apps/k8s/ --debug
+
+      - name: Check uat k8s helm charts
+        run: |
+          docker run --rm \
+            -v "$(pwd):/apps" \
+            -w /apps \
+            syd.ocir.io/coexservices01/alpine/helm:3.9.0 \
+            template -f /apps/k8s/values/values.uat.yaml --set "version=${{github.run_number}}" /apps/k8s/ --debug
+
+      - name: Check prod k8s helm charts
+        run: |
+          docker run --rm \
+            -v "$(pwd):/apps" \
+            -w /apps \
+            syd.ocir.io/coexservices01/alpine/helm:3.9.0 \
+            template -f /apps/k8s/values/values.prod.yaml --set "version=${{github.run_number}}" /apps/k8s/ --debug
+
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Setup github packages maven settings file
+        uses: whelk-io/maven-settings-xml-action@v4
+        with:
+          repositories: '[ { "id": "github", "url": "https://maven.pkg.github.com/coexservices/*" } ]'
+          servers: '[ { "id": "github", "username": "${GITHUB_ACTOR}", "password": "${GITHUB_TOKEN}" } ]'
+
+      - name: Build with Maven
+        run: |
+          echo Building version ${{github.run_number}}
+          mvn versions:set -DnewVersion=${{ github.run_number }}
+          mvn -ntp clean install -DbuildVersion=${{github.run_number}}
+        env:
+          GITHUB_ACTOR: ${{ secrets.CES_GITHUB_PACKAGES_READ_ACTOR }}
+          GITHUB_TOKEN: ${{ secrets.CES_GITHUB_PACKAGES_READ_TOKEN }}


### PR DESCRIPTION
This commit adds `java-17-validate-pr` reusable workflow that

- Pre-check PR title and commit messages
- Check k8s configurations
- Run `mvn install`

Run example:
- Manual trigger, https://github.com/coexservices/ms-scheduler/actions/runs/3761962210/jobs/6394193327
- Default, https://github.com/coexservices/ms-scheduler/actions/runs/3761974031/jobs/6394214863
- With `check_all_commit_msg: true` https://github.com/coexservices/ms-scheduler/actions/runs/3761982943/jobs/6394232398
- When pre-commit file does not exist https://github.com/coexservices/ms-scheduler/actions/runs/3762175194/jobs/6394623725